### PR TITLE
Update backend to better link with frontend

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -6,7 +6,7 @@
 
 ## Authentication
 
-Most endpoints require a valid JWT in the `Authorization` header:
+Authentication is **optional**. Endpoints accept requests without a token. If you choose to log in, include a JWT in the `Authorization` header:
 
 ```
 Authorization: Bearer <your-jwt-token>
@@ -18,19 +18,13 @@ Authorization: Bearer <your-jwt-token>
 
 ### Authentication
 
-**POST** `signup`
-Creates a new user account.
+**POST** `users`
+Creates a new user with just a username.
 
 * **Body**
 
   ```json
-  {
-    "firstName": "John",
-    "lastName": "Doe",
-    "username": "johndoe",
-    "password": "password123",
-    "role": "doctor"
-  }
+  { "username": "alice" }
   ```
 
 * **Response (201)**
@@ -38,44 +32,30 @@ Creates a new user account.
   ```json
   {
     "message": "User created successfully",
-    "user": {
-      "id": 1,
-      "username": "johndoe",
-      "role": "doctor",
-      "first_name": "John",
-      "last_name": "Doe"
-    },
-    "token": "<jwt-token>"
+    "user": { "id": 1, "username": "alice" }
   }
   ```
 
 ---
 
-**POST** `login`
-Authenticates a user and returns a JWT.
+**POST** `session/login`
+Passwordless login (optional) that upserts the user and returns a JWT.
 
 * **Body**
 
   ```json
-  {
-    "username": "johndoe",
-    "password": "password123"
-  }
+  { "username": "alice" }
   ```
 
 * **Response (200)**
 
   ```json
   {
-    "message": "Login successful",
+    "token": "<jwt-token>",
     "user": {
       "id": 1,
-      "username": "johndoe",
-      "role": "doctor",
-      "first_name": "John",
-      "last_name": "Doe"
-    },
-    "token": "<jwt-token>"
+      "username": "alice"
+    }
   }
   ```
 
@@ -103,11 +83,9 @@ Fetches the current user’s profile.
 
 **GET** `patients`
 List all patients.
-(Requires role: admin, doctor, nurse)
 
 **POST** `patients`
 Create a new patient.
-(Requires role: admin, doctor, nurse)
 
 * **Body**
 
@@ -124,15 +102,12 @@ Create a new patient.
 
 **GET** `patients/{id}`
 Fetch a patient by ID.
-(Requires role: admin, doctor, nurse)
 
 **PUT** `patients/{id}`
 Update a patient’s info.
-(Requires role: admin, doctor, nurse)
 
 **DELETE** `patients/{id}`
 Delete a patient.
-(Requires role: admin, doctor)
 
 ---
 
@@ -140,7 +115,6 @@ Delete a patient.
 
 **POST** `patients/{id}/vitals`
 Add a vitals record to a patient.
-(Requires role: admin, doctor, nurse)
 
 * **Body**
 
@@ -157,7 +131,6 @@ Add a vitals record to a patient.
 
 **GET** `patients/{id}/vitals`
 List all vitals records for a patient.
-(Requires role: admin, doctor, nurse)
 
 ---
 
@@ -165,11 +138,9 @@ List all vitals records for a patient.
 
 **POST** `patients/{id}/hef`
 Add an HEF record.
-(Requires role: admin, doctor, nurse)
 
 **GET** `patients/{id}/hef`
 List HEF records.
-(Requires role: admin, doctor, nurse)
 
 ---
 
@@ -177,11 +148,9 @@ List HEF records.
 
 **POST** `patients/{id}/visual_acuity`
 Add a visual acuity record.
-(Requires role: admin, doctor, nurse)
 
 **GET** `patients/{id}/visual_acuity`
 List visual acuity records.
-(Requires role: admin, doctor, nurse)
 
 ---
 
@@ -189,11 +158,9 @@ List visual acuity records.
 
 **POST** `patients/{id}/presenting_complaint`
 Add a presenting complaint.
-(Requires role: admin, doctor)
 
 **GET** `patients/{id}/presenting_complaint`
 List presenting complaints.
-(Requires role: admin, doctor, nurse)
 
 ---
 
@@ -201,11 +168,9 @@ List presenting complaints.
 
 **POST** `patients/{id}/history`
 Add a history record.
-(Requires role: admin, doctor)
 
 **GET** `patients/{id}/history`
 List history records.
-(Requires role: admin, doctor, nurse)
 
 ---
 
@@ -213,11 +178,9 @@ List history records.
 
 **POST** `patients/{id}/consultations`
 Create a consultation.
-(Requires role: admin, doctor)
 
 **GET** `patients/{id}/consultations`
 List consultations for a patient.
-(Requires role: admin, doctor, nurse)
 
 ---
 
@@ -225,11 +188,9 @@ List consultations for a patient.
 
 **POST** `consultations/{id}/referrals`
 Add a referral to a consultation.
-(Requires role: admin, doctor)
 
 **GET** `consultations/{id}/referrals`
 List referrals for a consultation.
-(Requires role: admin, doctor, nurse)
 
 ---
 
@@ -237,11 +198,23 @@ List referrals for a consultation.
 
 **POST** `patients/{id}/physiotherapy`
 Add a physiotherapy record.
-(Requires role: admin, doctor)
 
 **GET** `patients/{id}/physiotherapy`
 List physiotherapy records.
-(Requires role: admin, doctor, nurse)
+
+---
+
+### Combined Registration
+
+**POST** `registration`  
+Create a patient and optionally append vitals, HEF, and visit in one request.
+
+**PUT** `registration/{patientId}`  
+**Combined update (patient + optional append vitals/HEF/visit)**  
+Update patient data and optionally append a vitals record, HEF record, and/or visit in a single call.
+
+**DELETE** `registration/{patientId}`  
+Delete a patient (cascades to vitals/HEF/visits).
 
 ---
 
@@ -283,14 +256,6 @@ List physiotherapy records.
     "message": "Internal server error"
   }
   ```
-
----
-
-## User Roles
-
-* **admin**: Full access
-* **doctor**: Manage patients, consultations, referrals, physiotherapy
-* **nurse**: View patients; add vitals, HEF, visual acuity
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,15 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^5.1.1",
-        "body-parser": "^1.20.2",
+        "body-parser": "^1.20.3",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
-        "express": "^4.19.2",
-        "express-rate-limit": "^7.1.5",
-        "express-validator": "^7.0.1",
-        "helmet": "^7.1.0",
+        "express": "^4.21.2",
+        "express-rate-limit": "^7.5.1",
+        "express-validator": "^7.2.1",
+        "helmet": "^7.2.0",
         "jsonwebtoken": "^9.0.2",
-        "pg": "^8.11.5"
+        "pg": "^8.16.3"
       },
       "devDependencies": {
         "eslint": "^8.57.0",
@@ -1830,7 +1830,6 @@
       "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-5.1.1.tgz",
       "integrity": "sha512-AGBHOG5hPYZ5Xl9KXzU5iKq9516yEmvCKDg3ecP5kX2aB6UqTeXZxk2ELnDgDm6BQSMlLt9rDB4LoSMx0rYwww==",
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^1.0.11",
         "node-addon-api": "^5.0.0"
@@ -1856,7 +1855,6 @@
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
       "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "content-type": "~1.0.5",
@@ -2282,7 +2280,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -2916,7 +2913,6 @@
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
-      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2962,7 +2958,6 @@
       "version": "7.5.1",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
       "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
@@ -2977,7 +2972,6 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
       "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",
         "validator": "~13.12.0"
@@ -3118,11 +3112,10 @@
       "license": "ISC"
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3459,7 +3452,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-7.2.0.tgz",
       "integrity": "sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==",
-      "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
       }
@@ -4526,7 +4518,6 @@
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-      "license": "MIT",
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -5297,7 +5288,6 @@
       "version": "8.16.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
-      "license": "MIT",
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
   },
   "dependencies": {
     "bcrypt": "^5.1.1",
-    "body-parser": "^1.20.2",
+    "body-parser": "^1.20.3",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
-    "express": "^4.19.2",
-    "express-rate-limit": "^7.1.5",
-    "express-validator": "^7.0.1",
-    "helmet": "^7.1.0",
+    "express": "^4.21.2",
+    "express-rate-limit": "^7.5.1",
+    "express-validator": "^7.2.1",
+    "helmet": "^7.2.0",
     "jsonwebtoken": "^9.0.2",
-    "pg": "^8.11.5"
+    "pg": "^8.16.3"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/routes/api.js
+++ b/routes/api.js
@@ -3,15 +3,16 @@
 const express = require('express');
 const router = express.Router();
 
+const sessionRoutes = require('./session');
 const patientRoutes = require('./patients');
 const locationRoutes = require('./locations');
+const registrationRoutes = require('./registration');
 
+router.use('/auth', sessionRoutes);
 router.use('/patients', patientRoutes);
 router.use('/locations', locationRoutes);
+router.use('/registration', registrationRoutes);
 
-module.exports = router;
-
-const jwt = require('jsonwebtoken');
 const { body } = require('express-validator');
 const db = require('../config/db');
 const { authenticateToken, requireRole, validateRequest } = require('./auth');
@@ -22,8 +23,7 @@ const { authenticateToken, requireRole, validateRequest } = require('./auth');
 router.get('/users', async (req, res) => {
   try {
     const { rows } = await db.query(
-      `SELECT
-         username
+      `SELECT username
        FROM users
        ORDER BY created_at DESC`
     );
@@ -67,19 +67,20 @@ router.post(
 // Create a new patient
 router.post('/patients', [
   authenticateToken,
-  requireRole(['admin', 'doctor', 'nurse']),
+  requireRole(['any']),
   body('english_name').notEmpty().withMessage('English name is required'),
   body('date_of_birth').isISO8601().withMessage('Valid date of birth is required'),
-  body('sex').isIn(['male', 'female', 'other']).withMessage('Valid sex is required')
+  body('sex').isIn(['male', 'female', 'other']).withMessage('Valid sex is required'),
+  body('location_id').isInt({ min: 1 }).withMessage('location_id is required'),
 ], validateRequest, async (req, res) => {
   try {
-    const { english_name, khmer_name, date_of_birth, sex, phone_number, address } = req.body;
+    const { english_name, khmer_name, date_of_birth, sex, phone_number, address, location_id, queue_no } = req.body;
     const query = `
-      INSERT INTO patients(english_name, khmer_name, date_of_birth, sex, phone_number, address)
-      VALUES($1, $2, $3, $4, $5, $6)
+      INSERT INTO patients(english_name, khmer_name, date_of_birth, sex, phone_number, address, location_id, queue_no)
+      VALUES($1, $2, $3, $4, $5, $6, $7, $8)
       RETURNING *;
     `;
-    const values = [english_name, khmer_name, date_of_birth, sex, phone_number, address];
+    const values = [english_name, khmer_name, date_of_birth, sex, phone_number, address, location_id, queue_no ? String(queue_no).toUpperCase() : null];
     const { rows } = await db.query(query, values);
     res.status(201).json(rows[0]);
   } catch (error) {
@@ -88,11 +89,30 @@ router.post('/patients', [
   }
 });
 
-// Get all patients
-router.get('/patients', [authenticateToken, requireRole(['admin', 'doctor', 'nurse'])], async (req, res) => {
+// Get all patients (filter by location_id or location name)
+router.get('/patients', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
-    const { rows } = await db.query('SELECT * FROM patients ORDER BY created_at DESC');
-    res.json(rows);
+    const { location_id, location } = req.query;
+
+    let sql = `
+      SELECT p.*, l.name AS location_name
+      FROM patients p
+      JOIN locations l ON l.id = p.location_id
+    `;
+    const vals = [];
+
+    if (location_id) {
+      sql += ' WHERE p.location_id = $1';
+      vals.push(Number(location_id));
+    } else if (location) {
+      sql += ' WHERE LOWER(l.name) = LOWER($1)';
+      vals.push(location);
+    }
+
+    sql += ' ORDER BY p.created_at DESC';
+
+    const result = await db.query(sql, vals);
+    res.json(result.rows);
   } catch (error) {
     console.error('Get Patients Error:', error);
     res.status(500).json({ message: 'Internal server error' });
@@ -100,9 +120,15 @@ router.get('/patients', [authenticateToken, requireRole(['admin', 'doctor', 'nur
 });
 
 // Get a single patient by ID
-router.get('/patients/:id', [authenticateToken, requireRole(['admin', 'doctor', 'nurse'])], async (req, res) => {
+router.get('/patients/:id', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
-    const { rows } = await db.query('SELECT * FROM patients WHERE id = $1', [req.params.id]);
+    const { rows } = await db.query(
+      `SELECT p.*, l.name AS location_name
+         FROM patients p
+         JOIN locations l ON l.id = p.location_id
+        WHERE p.id = $1`,
+      [req.params.id]
+    );
     if (!rows.length) return res.status(404).json({ message: 'Patient not found' });
     res.json(rows[0]);
   } catch (error) {
@@ -114,18 +140,18 @@ router.get('/patients/:id', [authenticateToken, requireRole(['admin', 'doctor', 
 // Update patient info
 router.put('/patients/:id', [
   authenticateToken,
-  requireRole(['admin', 'doctor', 'nurse']),
+  requireRole(['any']),
   body('english_name').notEmpty().withMessage('English name is required'),
   body('date_of_birth').isISO8601().withMessage('Valid date of birth is required'),
   body('sex').isIn(['male', 'female', 'other']).withMessage('Valid sex is required')
 ], validateRequest, async (req, res) => {
   try {
-    const { english_name, khmer_name, date_of_birth, sex, phone_number, address } = req.body;
+    const { english_name, khmer_name, date_of_birth, sex, phone_number, address, location_id, queue_no } = req.body;
     const query = `
-      UPDATE patients SET english_name=$1, khmer_name=$2, date_of_birth=$3, sex=$4, phone_number=$5, address=$6
-      WHERE id=$7 RETURNING *;
+      UPDATE patients SET english_name=$1, khmer_name=$2, date_of_birth=$3, sex=$4, phone_number=$5, address=$6, location_id = COALESCE($7, location_id), queue_no = COALESCE($8, queue_no)
+      WHERE id=$9 RETURNING *;
     `;
-    const values = [english_name, khmer_name, date_of_birth, sex, phone_number, address, req.params.id];
+    const values = [english_name, khmer_name, date_of_birth, sex, phone_number, address, location_id || null, queue_no ? String(queue_no).toUpperCase() : null, req.params.id];
     const { rows } = await db.query(query, values);
     if (!rows.length) return res.status(404).json({ message: 'Patient not found' });
     res.json(rows[0]);
@@ -136,11 +162,11 @@ router.put('/patients/:id', [
 });
 
 // Delete patient
-router.delete('/patients/:id', [authenticateToken, requireRole(['admin', 'doctor'])], async (req, res) => {
+router.delete('/patients/:id', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
-    const { rows } = await db.query('DELETE FROM patients WHERE id = $1 RETURNING *', [req.params.id]);
+    const { rows } = await db.query('DELETE FROM patients WHERE id = $1 RETURNING id', [req.params.id]);
     if (!rows.length) return res.status(404).json({ message: 'Patient not found' });
-    res.json({ message: 'Patient deleted successfully' });
+    res.json({ message: 'Patient deleted successfully', patient_id: rows[0].id });
   } catch (error) {
     console.error('Delete Patient Error:', error);
     res.status(500).json({ message: 'Internal server error' });
@@ -152,7 +178,7 @@ router.delete('/patients/:id', [authenticateToken, requireRole(['admin', 'doctor
 // Add vitals for a patient
 router.post('/patients/:id/vitals', [
   authenticateToken,
-  requireRole(['admin', 'doctor', 'nurse']),
+  requireRole(['any']),
   body('weight_kg').isFloat({ min: 0 }).withMessage('Valid weight is required'),
   body('height_cm').isFloat({ min: 0 }).withMessage('Valid height is required')
 ], validateRequest, async (req, res) => {
@@ -171,8 +197,45 @@ router.post('/patients/:id/vitals', [
   }
 });
 
+// Update a vitals record
+router.put('/patients/:id/vitals/:vitalsId', [authenticateToken, requireRole(['any'])], async (req, res) => {
+  try {
+    const { height_cm, weight_kg, bmi, blood_pressure, temperature_c, vitals_notes } = req.body;
+    const { id, vitalsId } = req.params;
+    const upd = await db.query(
+      `UPDATE vitals
+         SET height_cm = COALESCE($1, height_cm),
+             weight_kg = COALESCE($2, weight_kg),
+             bmi = COALESCE($3, bmi),
+             blood_pressure = COALESCE($4, blood_pressure),
+             temperature_c = COALESCE($5, temperature_c),
+             vitals_notes = COALESCE($6, vitals_notes)
+       WHERE id = $7 AND patient_id = $8
+       RETURNING *`,
+      [height_cm || null, weight_kg || null, bmi || null, blood_pressure || null, temperature_c || null, vitals_notes || null, vitalsId, id]
+    );
+    if (!upd.rows.length) return res.status(404).json({ message: 'Vitals not found' });
+    res.json(upd.rows[0]);
+  } catch (error) {
+    console.error('Update Vitals Error:', error);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
+// Delete a vitals record
+router.delete('/patients/:id/vitals/:vitalsId', [authenticateToken, requireRole(['any'])], async (req, res) => {
+  try {
+    const del = await db.query('DELETE FROM vitals WHERE id = $1 AND patient_id = $2 RETURNING id', [req.params.vitalsId, req.params.id]);
+    if (!del.rows.length) return res.status(404).json({ message: 'Vitals not found' });
+    res.json({ message: 'Vitals deleted', id: del.rows[0].id });
+  } catch (error) {
+    console.error('Delete Vitals Error:', error);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
 // Get vitals for a patient
-router.get('/patients/:id/vitals', [authenticateToken, requireRole(['admin', 'doctor', 'nurse'])], async (req, res) => {
+router.get('/patients/:id/vitals', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
     const { rows } = await db.query('SELECT * FROM vitals WHERE patient_id=$1 ORDER BY created_at DESC', [req.params.id]);
     res.json(rows);
@@ -187,7 +250,7 @@ router.get('/patients/:id/vitals', [authenticateToken, requireRole(['admin', 'do
 // Add HEF for a patient
 router.post('/patients/:id/hef', [
   authenticateToken,
-  requireRole(['admin', 'doctor', 'nurse']),
+  requireRole(['any']),
   body('know_hef').isBoolean().withMessage('know_hef is required'),
   body('have_hef').isBoolean().withMessage('have_hef is required')
 ], validateRequest, async (req, res) => {
@@ -203,8 +266,44 @@ router.post('/patients/:id/hef', [
   }
 });
 
+// Update HEF
+router.put('/patients/:id/hef/:hefId', [authenticateToken, requireRole(['any'])], async (req, res) => {
+  try {
+    const { know_hef, have_hef, hef_notes } = req.body;
+    const upd = await db.query(
+      `UPDATE hef
+          SET know_hef = COALESCE($1, know_hef),
+              have_hef = COALESCE($2, have_hef),
+              hef_notes = COALESCE($3, hef_notes)
+        WHERE id = $4 AND patient_id = $5
+        RETURNING *`,
+      [typeof know_hef === 'boolean' ? know_hef : null,
+       typeof have_hef === 'boolean' ? have_hef : null,
+       hef_notes || null,
+       req.params.hefId, req.params.id]
+    );
+    if (!upd.rows.length) return res.status(404).json({ message: 'HEF not found' });
+    res.json(upd.rows[0]);
+  } catch (error) {
+    console.error('Update HEF Error:', error);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
+// Delete HEF
+router.delete('/patients/:id/hef/:hefId', [authenticateToken, requireRole(['any'])], async (req, res) => {
+  try {
+    const del = await db.query('DELETE FROM hef WHERE id = $1 AND patient_id = $2 RETURNING id', [req.params.hefId, req.params.id]);
+    if (!del.rows.length) return res.status(404).json({ message: 'HEF not found' });
+    res.json({ message: 'HEF deleted', id: del.rows[0].id });
+  } catch (error) {
+    console.error('Delete HEF Error:', error);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
 // Get HEF records for a patient
-router.get('/patients/:id/hef', [authenticateToken, requireRole(['admin', 'doctor', 'nurse'])], async (req, res) => {
+router.get('/patients/:id/hef', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
     const { rows } = await db.query('SELECT * FROM hef WHERE patient_id=$1 ORDER BY created_at DESC', [req.params.id]);
     res.json(rows);
@@ -219,9 +318,11 @@ router.get('/patients/:id/hef', [authenticateToken, requireRole(['admin', 'docto
 // Add visual acuity for a patient
 router.post('/patients/:id/visual_acuity', [
   authenticateToken,
-  requireRole(['admin', 'doctor', 'nurse']),
+  requireRole(['any']),
   body('left_pin').notEmpty().withMessage('Left pin is required'),
-  body('right_pin').notEmpty().withMessage('Right pin is required')
+  body('right_pin').notEmpty().withMessage('Right pin is required'),
+  body('left_no_pin').notEmpty().withMessage('Left no-pin is required'),
+  body('right_no_pin').notEmpty().withMessage('Right no-pin is required'),
 ], validateRequest, async (req, res) => {
   try {
     const { left_pin, left_no_pin, right_pin, right_no_pin, visual_notes } = req.body;
@@ -239,7 +340,7 @@ router.post('/patients/:id/visual_acuity', [
 });
 
 // Get visual acuity records for a patient
-router.get('/patients/:id/visual_acuity', [authenticateToken, requireRole(['admin', 'doctor', 'nurse'])], async (req, res) => {
+router.get('/patients/:id/visual_acuity', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
     const { rows } = await db.query('SELECT * FROM visual_acuity WHERE patient_id=$1 ORDER BY created_at DESC', [req.params.id]);
     res.json(rows);
@@ -254,7 +355,7 @@ router.get('/patients/:id/visual_acuity', [authenticateToken, requireRole(['admi
 // Add presenting complaint
 router.post('/patients/:id/presenting_complaint', [
   authenticateToken,
-  requireRole(['admin', 'doctor']),
+  requireRole(['any']),
   body('history').notEmpty().withMessage('History is required')
 ], validateRequest, async (req, res) => {
   try {
@@ -273,7 +374,7 @@ router.post('/patients/:id/presenting_complaint', [
 });
 
 // Get presenting complaints for a patient
-router.get('/patients/:id/presenting_complaint', [authenticateToken, requireRole(['admin','doctor','nurse'])], async (req, res) => {
+router.get('/patients/:id/presenting_complaint', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
     const { rows } = await db.query('SELECT * FROM presenting_complaint WHERE patient_id=$1 ORDER BY created_at DESC', [req.params.id]);
     res.json(rows);
@@ -288,7 +389,7 @@ router.get('/patients/:id/presenting_complaint', [authenticateToken, requireRole
 // Add history record
 router.post('/patients/:id/history', [
   authenticateToken,
-  requireRole(['admin', 'doctor']),
+  requireRole(['any']),
   body('past').notEmpty().withMessage('Past history is required')
 ], validateRequest, async (req, res) => {
   try {
@@ -307,7 +408,7 @@ router.post('/patients/:id/history', [
 });
 
 // Get history records for a patient
-router.get('/patients/:id/history', [authenticateToken, requireRole(['admin','doctor','nurse'])], async (req, res) => {
+router.get('/patients/:id/history', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
     const { rows } = await db.query('SELECT * FROM history WHERE patient_id=$1 ORDER BY created_at DESC', [req.params.id]);
     res.json(rows);
@@ -321,8 +422,8 @@ router.get('/patients/:id/history', [authenticateToken, requireRole(['admin','do
 
 // Create a consultation
 router.post('/patients/:id/consultations', [
-  authenticateToken,
-  requireRole(['admin', 'doctor']),
+  authenticateToken,  
+  requireRole(['any']),
   body('consultation_notes').notEmpty().withMessage('Consultation notes are required')
 ], validateRequest, async (req, res) => {
   try {
@@ -341,7 +442,7 @@ router.post('/patients/:id/consultations', [
 });
 
 // Get consultations for a patient
-router.get('/patients/:id/consultations', [authenticateToken, requireRole(['admin','doctor','nurse'])], async (req, res) => {
+router.get('/patients/:id/consultations', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
     const { rows } = await db.query('SELECT * FROM consultation WHERE patient_id=$1 ORDER BY created_at DESC', [req.params.id]);
     res.json(rows);
@@ -356,7 +457,7 @@ router.get('/patients/:id/consultations', [authenticateToken, requireRole(['admi
 // Add a referral for a consultation
 router.post('/consultations/:id/referrals', [
   authenticateToken,
-  requireRole(['admin','doctor']),
+  requireRole(['any']),
   body('referral_type').isIn([    'MongKol Borey Hospital', 'Optometrist', 'Dentist','Poipet Referral Hospital','Bong Bondol','SEVA','WSAudiology' ]).withMessage('Invalid referral type')
 ], validateRequest, async (req, res) => {
   try {
@@ -379,7 +480,7 @@ router.post('/consultations/:id/referrals', [
 });
 
 // Get referrals for a consultation
-router.get('/consultations/:id/referrals', [authenticateToken, requireRole(['admin','doctor','nurse'])], async (req, res) => {
+router.get('/consultations/:id/referrals', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
     const { rows } = await db.query('SELECT * FROM referral WHERE consultation_id=$1 ORDER BY created_at DESC', [req.params.id]);
     res.json(rows);
@@ -394,7 +495,7 @@ router.get('/consultations/:id/referrals', [authenticateToken, requireRole(['adm
 // Add physiotherapy for a patient
 router.post('/patients/:id/physiotherapy', [
   authenticateToken,
-  requireRole(['admin','doctor']),
+  requireRole(['any']),
   body('pain_areas_description').notEmpty().withMessage('Pain areas description is required')
 ], validateRequest, async (req, res) => {
   try {
@@ -411,7 +512,7 @@ router.post('/patients/:id/physiotherapy', [
 });
 
 // Get physiotherapy records for a patient
-router.get('/patients/:id/physiotherapy', [authenticateToken, requireRole(['admin','doctor','nurse'])], async (req, res) => {
+router.get('/patients/:id/physiotherapy', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
     const { rows } = await db.query('SELECT * FROM physiotherapy WHERE patient_id=$1 ORDER BY created_at DESC', [req.params.id]);
     res.json(rows);
@@ -421,46 +522,40 @@ router.get('/patients/:id/physiotherapy', [authenticateToken, requireRole(['admi
   }
 });
 
-// --- Locations Management ---
+// --- Visits: update queue number of a specific visit ---
 
-// Get all distinct locations from patient addresses
-router.get('/locations', authenticateToken, async (req, res) => {
+// Update a visit’s queue number
+router.put('/visits/:id', [authenticateToken, requireRole(['any'])], async (req, res) => {
   try {
-    const { rows } = await db.query(`
-      SELECT DISTINCT location
-      FROM patients
-      WHERE location IS NOT NULL
-      ORDER BY location
-    `);
-    const locations = rows.map(r => r.location);
-    res.json({ locations });
-  } catch (error) {
-    console.error('Get Locations Error:', error);
-    res.status(500).json({ message: 'Internal server error' });
-  }
-});
-
-// Get patients filtered by location
-router.get('/patients', [
-  authenticateToken,
-  requireRole(['admin', 'doctor', 'nurse'])
-], async (req, res) => {
-  try {
-    const { location } = req.query;
-    let queryText = 'SELECT * FROM patients';
-    let values = [];
-
-    if (location) {
-      queryText += ' WHERE location = $1';
-      values.push(location);
+    if (!req.body.queue_no || !String(req.body.queue_no).trim()) {
+      return res.status(400).json({ message: 'queue_no is required' });
+    }
+    const queueToken = String(req.body.queue_no).trim().toUpperCase();
+    if (!/^[0-9]+[A-Z]*$/.test(queueToken)) {
+      return res.status(400).json({ message: 'queue_no must be a number with optional A–Z suffix, e.g. 2A, 102B, 1000' });
     }
 
-    queryText += ' ORDER BY created_at DESC';
+    // Get current visit to know patient/location/date for uniqueness and mirroring
+    const cur = await db.query(
+      `SELECT id, patient_id, location_id, visit_date FROM visits WHERE id = $1`,
+      [ req.params.id ]
+    );
+    if (!cur.rows.length) return res.status(404).json({ message: 'Visit not found' });
 
-    const { rows } = await db.query(queryText, values);
-    res.json(rows);
-  } catch (error) {
-    console.error('Get Patients Error:', error);
+    const upd = await db.query(
+      `UPDATE visits SET queue_no = $1 WHERE id = $2 RETURNING *`,
+      [ queueToken, req.params.id ]
+    );
+
+    // Mirror queue to patient
+    await db.query(`UPDATE patients SET queue_no = $1 WHERE id = $2`, [ queueToken, cur.rows[0].patient_id ]);
+
+    res.json(upd.rows[0]);
+  } catch (err) {
+    if (err && err.code === '23505') {
+      return res.status(409).json({ message: 'Duplicate queue number for this location and date' });
+    }
+    console.error('Update Visit queue_no error:', err);
     res.status(500).json({ message: 'Internal server error' });
   }
 });

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -8,13 +8,17 @@ const authenticateToken = (req, res, next) => {
   const authHeader = req.headers['authorization'];
   const token = authHeader && authHeader.split(' ')[1]; // Bearer TOKEN
 
+  // If no token, allow through and set a benign user (no role checks enforced)
   if (!token) {
-    return res.status(401).json({ message: 'Access token required' });
+    req.user = { id: null, username: 'public' };
+    return next();
   }
 
   jwt.verify(token, process.env.JWT_SECRET, (err, user) => {
     if (err) {
-      return res.status(403).json({ message: 'Invalid or expired token' });
+      // If invalid token, still allow through as public
+      req.user = { id: null, username: 'public' };
+      return next();
     }
     req.user = user;
     next();
@@ -22,19 +26,7 @@ const authenticateToken = (req, res, next) => {
 };
 
 // Middleware to check if user has required role
-const requireRole = (roles) => {
-  return (req, res, next) => {
-    if (!req.user) {
-      return res.status(401).json({ message: 'Authentication required' });
-    }
-
-    if (!roles.includes(req.user.role)) {
-      return res.status(403).json({ message: 'Insufficient permissions' });
-    }
-
-    next();
-  };
-};
+const requireRole = (_roles) => (_req, _res, next) => next();
 
 // Middleware to validate request data
 const validateRequest = (req, res, next) => {

--- a/routes/locations.js
+++ b/routes/locations.js
@@ -2,20 +2,19 @@
 
 const express = require('express');
 const router = express.Router();
-const pool = require('../config/db');
+const db = require('../config/db');
 const { authenticateToken } = require('../routes/auth');
 
 router.get('/', authenticateToken, async (req, res) => {
   try {
-    const result = await pool.query(`
-      SELECT DISTINCT address
-      FROM patients
-      WHERE address IS NOT NULL AND address <> ''
-      ORDER BY address
+    const result = await db.query(`
+      SELECT id, name 
+      FROM locations 
+      WHERE is_active = TRUE 
+      ORDER BY name
     `);
 
-    const locations = result.rows.map(row => row.address);
-    res.json({ locations });
+    res.json({ locations: result.rows });
   } catch (err) {
     console.error('Error fetching locations:', err);
     res.status(500).json({ error: 'Internal server error' });

--- a/routes/registration.js
+++ b/routes/registration.js
@@ -1,0 +1,224 @@
+// routes/registration.js
+
+const express = require('express');
+const router = express.Router();
+const db = require('../config/db');
+const { authenticateToken, requireRole } = require('./auth');
+
+/**
+ * POST /api/registration
+ * Creates patient + (optional) vitals + (optional) hef + (optional) visit/queue
+ * Body:
+ * {
+ *   "patient": { english_name, khmer_name, date_of_birth, sex, phone_number, address, location_id },
+ *   "vitals": { height_cm, weight_kg, bmi, blood_pressure, temperature_c, vitals_notes },        // optional
+ *   "hef": { know_hef, have_hef, hef_notes },                                                    // optional
+ *   "visit": { location_id, visit_date, queue_no }                                               // optional (creates queue)
+ * }
+ */
+router.post('/', authenticateToken, requireRole(['any']), async (req, res) => {
+  const { patient, vitals, hef, visit } = req.body;
+  if (!patient || !patient.english_name || !patient.location_id) {
+    return res.status(400).json({ message: 'patient.english_name and patient.location_id are required' });
+  }
+
+  const client = await db.pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const pRes = await client.query(
+      `INSERT INTO patients(english_name, khmer_name, date_of_birth, sex, phone_number, address, location_id)
+       VALUES($1,$2,$3,$4,$5,$6,$7)
+       RETURNING *`,
+      [
+        patient.english_name, patient.khmer_name || null, patient.date_of_birth || null,
+        patient.sex || null, patient.phone_number || null, patient.address || null,
+        patient.location_id
+      ]
+    );
+    const newPatient = pRes.rows[0];
+
+    let vitalsRow = null;
+    if (vitals) {
+      const vRes = await client.query(
+        `INSERT INTO vitals(patient_id, height_cm, weight_kg, bmi, blood_pressure, temperature_c, vitals_notes)
+         VALUES($1,$2,$3,$4,$5,$6,$7) RETURNING *`,
+        [
+          newPatient.id, vitals.height_cm || null, vitals.weight_kg || null, vitals.bmi || null,
+          vitals.blood_pressure || null, vitals.temperature_c || null, vitals.vitals_notes || null
+        ]
+      );
+      vitalsRow = vRes.rows[0];
+    }
+
+    let hefRow = null;
+    if (hef) {
+      const hRes = await client.query(
+        `INSERT INTO hef(patient_id, know_hef, have_hef, hef_notes)
+         VALUES($1,$2,$3,$4) RETURNING *`,
+        [ newPatient.id, !!hef.know_hef, !!hef.have_hef, hef.hef_notes || null ]
+      );
+      hefRow = hRes.rows[0];
+    }
+
+    let visitRow = null;
+    if (visit && visit.location_id) {
+      const visitDate = visit.visit_date || new Date().toISOString().slice(0,10);
+      if (!visit.queue_no || !String(visit.queue_no).trim()) {
+        return res.status(400).json({ message: 'visit.queue_no is required (e.g., "2A", "3")' });
+      }
+      const queueToken = String(visit.queue_no).trim().toUpperCase();
+      const insV = await client.query(
+        `INSERT INTO visits(patient_id, location_id, visit_date, queue_no)
+         VALUES($1,$2,$3,$4) RETURNING *`,
+        [ newPatient.id, visit.location_id, visitDate, queueToken ]
+      );
+      visitRow = insV.rows[0];
+
+      // Mirror on patient for quick lookup
+      await client.query(
+        `UPDATE patients SET queue_no = $1 WHERE id = $2`,
+        [ queueToken, newPatient.id ]
+      );
+      // Ensure the response also shows the mirrored queue number
+      newPatient.queue_no = queueToken;
+    }
+
+    await client.query('COMMIT');
+    res.status(201).json({ patient: newPatient, vitals: vitalsRow, hef: hefRow, visit: visitRow });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    if (err && err.code === '23505') {
+      return res.status(409).json({ message: 'Duplicate queue number for this location and date' });
+    }
+    console.error('Registration create error:', err);
+    res.status(500).json({ message: 'Internal server error' });
+  } finally {
+    client.release();
+  }
+});
+
+/**
+ * PUT /api/registration/:patientId
+ * Updates patient fields; optionally appends a new vitals/hef record.
+ * (Vitals/HEF are append-only for audit.)
+ */
+router.put('/:patientId', authenticateToken, requireRole(['any']), async (req, res) => {
+  const { patient, vitals, hef, visit } = req.body;
+  const { patientId } = req.params;
+
+  const client = await db.pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    let updatedPatient = null;
+    if (patient) {
+      const uRes = await client.query(
+        `UPDATE patients
+            SET english_name = COALESCE($1, english_name),
+                khmer_name   = COALESCE($2, khmer_name),
+                date_of_birth= COALESCE($3, date_of_birth),
+                sex          = COALESCE($4, sex),
+                phone_number = COALESCE($5, phone_number),
+                address      = COALESCE($6, address),
+                location_id  = COALESCE($7, location_id)
+          WHERE id = $8
+        RETURNING *`,
+        [
+          patient.english_name || null, patient.khmer_name || null, patient.date_of_birth || null,
+          patient.sex || null, patient.phone_number || null, patient.address || null,
+          patient.location_id || null, patientId
+        ]
+      );
+      if (!uRes.rows.length) return res.status(404).json({ message: 'Patient not found' });
+      updatedPatient = uRes.rows[0];
+    }
+
+    let vitalsRow = null;
+    if (vitals) {
+      const vRes = await client.query(
+        `INSERT INTO vitals(patient_id, height_cm, weight_kg, bmi, blood_pressure, temperature_c, vitals_notes)
+         VALUES($1,$2,$3,$4,$5,$6,$7) RETURNING *`,
+        [
+          patientId, vitals.height_cm || null, vitals.weight_kg || null, vitals.bmi || null,
+          vitals.blood_pressure || null, vitals.temperature_c || null, vitals.vitals_notes || null
+        ]
+      );
+      vitalsRow = vRes.rows[0];
+    }
+
+    let hefRow = null;
+    if (hef) {
+      const hRes = await client.query(
+        `INSERT INTO hef(patient_id, know_hef, have_hef, hef_notes)
+         VALUES($1,$2,$3,$4) RETURNING *`,
+        [ patientId, !!hef.know_hef, !!hef.have_hef, hef.hef_notes || null ]
+      );
+      hefRow = hRes.rows[0];
+    }
+
+    // Optionally update/create visit & mirror queue on patient
+    let visitRow = null;
+    if (visit && visit.location_id) {
+      const visitDate = visit.visit_date || new Date().toISOString().slice(0,10);
+      if (!visit.queue_no || !String(visit.queue_no).trim()) {
+        return res.status(400).json({ message: 'visit.queue_no is required when visit is provided' });
+      }
+      const queueToken = String(visit.queue_no).trim().toUpperCase();
+
+      // Try to find an existing visit for this patient/location/date
+      const existing = await client.query(
+        `SELECT id FROM visits WHERE patient_id = $1 AND location_id = $2 AND visit_date = $3`,
+        [ patientId, visit.location_id, visitDate ]
+      );
+
+      if (existing.rows.length) {
+        const upd = await client.query(
+          `UPDATE visits SET queue_no = $1 WHERE id = $2 RETURNING *`,
+          [ queueToken, existing.rows[0].id ]
+        );
+        visitRow = upd.rows[0];
+      } else {
+        const ins = await client.query(
+          `INSERT INTO visits(patient_id, location_id, visit_date, queue_no)
+           VALUES ($1,$2,$3,$4) RETURNING *`,
+          [ patientId, visit.location_id, visitDate, queueToken ]
+        );
+        visitRow = ins.rows[0];
+      }
+
+      // Mirror on patient
+      await client.query(`UPDATE patients SET queue_no = $1 WHERE id = $2`, [ queueToken, patientId ]);
+      if (updatedPatient) updatedPatient.queue_no = queueToken;
+    }
+
+    await client.query('COMMIT');
+    res.json({ patient: updatedPatient, vitals: vitalsRow, hef: hefRow, visit: visitRow });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    if (err && err.code === '23505') {
+      return res.status(409).json({ message: 'Duplicate queue number for this location and date' });
+    }
+    console.error('Registration update error:', err);
+    res.status(500).json({ message: 'Internal server error' });
+  } finally {
+    client.release();
+  }
+});
+
+/**
+ * DELETE /api/registration/:patientId
+ * Removes the patient (cascades to vitals/hef/visits due to FK ON DELETE CASCADE)
+ */
+router.delete('/:patientId', authenticateToken, requireRole(['any']), async (req, res) => {
+  try {
+    const del = await db.query('DELETE FROM patients WHERE id = $1 RETURNING id', [ req.params.patientId ]);
+    if (!del.rows.length) return res.status(404).json({ message: 'Patient not found' });
+    res.json({ message: 'Patient deleted', patient_id: del.rows[0].id });
+  } catch (err) {
+    console.error('Registration delete error:', err);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/routes/session.js
+++ b/routes/session.js
@@ -1,0 +1,39 @@
+// routes/session.js
+
+const express = require('express');
+const router = express.Router();
+const db = require('../config/db');
+const jwt = require('jsonwebtoken');
+
+router.post('/login', async (req, res) => {
+  const { username } = req.body;
+  if (!username || username.trim().length < 3) {
+    return res.status(400).json({ message: 'username (>=3 chars) is required' });
+  }
+
+  try {
+    // Upsert user by username (no password, no role)
+    const upsert = `
+      INSERT INTO users (username)
+      VALUES ($1)
+      ON CONFLICT (username) DO UPDATE SET username = EXCLUDED.username
+      RETURNING id, username;
+    `;
+    const { rows } = await db.query(upsert, [username.trim()]);
+    const user = rows[0];
+
+    // Sign a token with just id and username
+    const token = jwt.sign(
+      { id: user.id, username: user.username },
+      process.env.JWT_SECRET,
+      { expiresIn: '30d' }
+    );
+
+    res.json({ token, user });
+  } catch (err) {
+    console.error('Passwordless login error:', err);
+    res.status(500).json({ message: 'Internal server error' });
+  }
+});
+
+module.exports = router;

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,4 +1,5 @@
 // scripts/setup.js
+
 require('../server.js')
 const db = require('../config/db');
 const fs = require('fs');
@@ -58,7 +59,7 @@ async function runSetup() {
   console.log('\nNext steps:');
   console.log('1. Start the server: npm run dev');
   console.log('2. Test the API: curl http://localhost:3000/health');
-  console.log('3. Create your first user: POST /api/signup');
+  console.log('3. Create your first user: POST /api/users (body: { "username": "yourname" })');
 }
 
 runSetup().catch(console.error); 

--- a/server.js
+++ b/server.js
@@ -59,4 +59,4 @@ app.listen(PORT, () => {
   console.log(`Health check: http://localhost:${PORT}/health`);
 });
 
-// module.exports = app;
+module.exports = app;

--- a/tests/locations.test.js
+++ b/tests/locations.test.js
@@ -1,0 +1,15 @@
+// tests/locations.test.js
+
+const request = require('supertest');
+const app = require('../server');
+
+describe('Locations API', () => {
+  test('GET /api/locations returns active locations (public)', async () => {
+    const res = await request(app).get('/api/locations');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.locations)).toBe(true);
+    // seeded names
+    const names = res.body.locations.map(l => l.name);
+    expect(names).toEqual(expect.arrayContaining(['Poipet', 'Mongkol Borey', 'Sisophon']));
+  });
+});

--- a/tests/registration_and_components.test.js
+++ b/tests/registration_and_components.test.js
@@ -1,0 +1,130 @@
+// tests/registration_and_components.test.js
+
+const request = require('supertest');
+const app = require('../server');
+
+const pickLocationId = async () => {
+  const r = await request(app).get('/api/locations');
+  return r.body.locations[0].id;
+};
+
+describe('Combined registration + component CRUD + queue', () => {
+  let patientId;
+  let vitalsId;
+  let hefId;
+  let visitId;
+  let locationId;
+
+  beforeAll(async () => {
+    locationId = await pickLocationId();
+  });
+
+  test('POST /api/registration creates patient + vitals + hef + visit (public)', async () => {
+    const res = await request(app)
+      .post('/api/registration')
+      .send({
+        patient: {
+          english_name: 'Alice Test',
+          khmer_name: 'អាលីស',
+          date_of_birth: '1995-01-01',
+          sex: 'female',
+          phone_number: '+85512345',
+          address: 'Somewhere',
+          location_id: locationId
+        },
+        vitals: {
+          height_cm: 160, weight_kg: 50, bmi: 19.5, blood_pressure: '110/70', temperature_c: 36.6
+        },
+        hef: { know_hef: true, have_hef: false, hef_notes: 'N/A' },
+        visit: { location_id: locationId, visit_date: '2025-08-12', queue_no: '2a' } // lower-case to test uppercasing
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.patient.id).toBeDefined();
+    patientId = res.body.patient.id;
+
+    expect(res.body.vitals.id).toBeDefined();
+    vitalsId = res.body.vitals.id;
+
+    expect(res.body.hef.id).toBeDefined();
+    hefId = res.body.hef.id;
+
+    expect(res.body.visit.id).toBeDefined();
+    visitId = res.body.visit.id;
+
+    // queue mirrored to patient
+    expect(res.body.patient.queue_no).toBe('2A');
+  });
+
+  test('GET /api/patients?location_id filters by location and returns location_name', async () => {
+    const res = await request(app).get(`/api/patients?location_id=${locationId}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    const found = res.body.find(p => p.id === patientId);
+    expect(found).toBeTruthy();
+    expect(found.location_name).toBeDefined();
+  });
+
+  test('Individual Vitals: PUT updates, GET lists, DELETE removes', async () => {
+    const upd = await request(app)
+      .put(`/api/patients/${patientId}/vitals/${vitalsId}`)
+      .send({ weight_kg: 51 });
+    expect(upd.status).toBe(200);
+    expect(parseFloat(upd.body.weight_kg)).toBe(51);
+
+    const list = await request(app).get(`/api/patients/${patientId}/vitals`);
+    expect(list.status).toBe(200);
+    expect(list.body.some(v => v.id === vitalsId)).toBe(true);
+
+    const del = await request(app).delete(`/api/patients/${patientId}/vitals/${vitalsId}`);
+    expect(del.status).toBe(200);
+  });
+
+  test('Individual HEF: PUT updates, GET lists, DELETE removes', async () => {
+    const upd = await request(app)
+      .put(`/api/patients/${patientId}/hef/${hefId}`)
+      .send({ have_hef: true });
+    expect(upd.status).toBe(200);
+    expect(upd.body.have_hef).toBe(true);
+
+    const list = await request(app).get(`/api/patients/${patientId}/hef`);
+    expect(list.status).toBe(200);
+    expect(list.body.some(h => h.id === hefId)).toBe(true);
+
+    const del = await request(app).delete(`/api/patients/${patientId}/hef/${hefId}`);
+    expect(del.status).toBe(200);
+  });
+
+  test('Combined update: PUT /api/registration/:patientId can update patient & visit queue', async () => {
+    const res = await request(app)
+      .put(`/api/registration/${patientId}`)
+      .send({
+        patient: { phone_number: '+855999' },
+        visit: { location_id: locationId, visit_date: '2025-08-12', queue_no: '3B' }
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.visit.queue_no).toBe('3B');
+
+    // queue mirrored
+    const getP = await request(app).get(`/api/patients?location_id=${locationId}`);
+    const found = getP.body.find(p => p.id === patientId);
+    expect(found.queue_no).toBe('3B');
+  });
+
+  test('Visit queue update endpoint also mirrors to patient', async () => {
+    const res = await request(app)
+      .put(`/api/visits/${visitId}`)
+      .send({ queue_no: '10C' });
+    expect(res.status).toBe(200);
+    expect(res.body.queue_no).toBe('10C');
+
+    const getP = await request(app).get(`/api/patients?location_id=${locationId}`);
+    const found = getP.body.find(p => p.id === patientId);
+    expect(found.queue_no).toBe('10C');
+  });
+
+  test('Combined delete removes patient (and cascades)', async () => {
+    const del = await request(app).delete(`/api/registration/${patientId}`);
+    expect(del.status).toBe(200);
+  });
+});

--- a/tests/test_data.sql
+++ b/tests/test_data.sql
@@ -1,0 +1,155 @@
+BEGIN;
+
+-- ─────────────────────────────
+-- Users (username is UNIQUE)
+-- ─────────────────────────────
+INSERT INTO users (username) VALUES
+  ('alice'),    -- doctor
+  ('bob'),      -- nurse
+  ('charlie'),  -- doctor
+  ('davy')      -- physio
+ON CONFLICT (username) DO NOTHING;
+
+-- ─────────────────────────────
+-- Patients (spread across locations)
+-- NOTE: queue_no format = digits + optional A–Z suffix
+-- ─────────────────────────────
+INSERT INTO patients
+  (english_name, khmer_name, date_of_birth, sex, phone_number, address, location_id, queue_no)
+VALUES
+  -- Poipet
+  ('Sophea Chan',  'សុភា ចាន់',  '1985-03-14', 'female', '+85510100001', 'Thma Koul, Poipet', (SELECT id FROM locations WHERE name='Poipet'),         '1A'),
+  ('Vuthy Sorn',   'វុទ្ធី សូន',  '1979-08-22', 'male',   '+85510100002', 'Kbal Spean, Poipet', (SELECT id FROM locations WHERE name='Poipet'),        '2'),
+  ('Sareth Kim',   'សារ៉េត គីម',  '1992-12-05', 'male',   '+85510100003', 'O’Russey, Poipet',   (SELECT id FROM locations WHERE name='Poipet'),        NULL),
+
+  -- Mongkol Borey
+  ('Dara Long',    'ដារ៉ា លង',   '1990-01-11', 'male',   '+85510100004', 'Kouk Ballang, MB',    (SELECT id FROM locations WHERE name='Mongkol Borey'),'3B'),
+  ('Sreyneang Im', 'ស្រីណាង អ៊ីម', '1988-06-09', 'female', '+85510100005', 'Prey Chhor, MB',      (SELECT id FROM locations WHERE name='Mongkol Borey'),'4'),
+  ('Raksmey Oum',  'រាក់ស்மை អ៊ុំ', '1970-03-30', 'female', '+85510100006', 'Chamkar, MB',         (SELECT id FROM locations WHERE name='Mongkol Borey'),NULL),
+
+  -- Sisophon
+  ('Piseth Mean',  'ពីសេធ មៀន', '1995-05-17', 'male',   '+85510100007', 'Svay Dangkum, Siso',  (SELECT id FROM locations WHERE name='Sisophon'),     '5A'),
+  ('Sokunthea Ty', 'សុខន្ធា ទី', '1982-10-03', 'female', '+85510100008', 'Phsar Ler, Siso',     (SELECT id FROM locations WHERE name='Sisophon'),     '6'),
+  ('Makara Nuon',  'មករា នួន',  '2001-02-21', 'other',  '+85510100009', 'Kokor, Siso',         (SELECT id FROM locations WHERE name='Sisophon'),     NULL);
+
+-- ─────────────────────────────
+-- Visits (per-day per-location queues; mirror patient queue numbers)
+-- ─────────────────────────────
+-- Poipet 2025-08-12
+INSERT INTO visits (patient_id, location_id, visit_date, queue_no)
+VALUES
+  ((SELECT id FROM patients WHERE phone_number='+85510100001'), (SELECT id FROM locations WHERE name='Poipet'), '2025-08-12', '1A'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100002'), (SELECT id FROM locations WHERE name='Poipet'), '2025-08-12', '2');
+
+-- Mongkol Borey 2025-08-12
+INSERT INTO visits (patient_id, location_id, visit_date, queue_no)
+VALUES
+  ((SELECT id FROM patients WHERE phone_number='+85510100004'), (SELECT id FROM locations WHERE name='Mongkol Borey'), '2025-08-12', '3B'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100005'), (SELECT id FROM locations WHERE name='Mongkol Borey'), '2025-08-12', '4');
+
+-- Sisophon 2025-08-12
+INSERT INTO visits (patient_id, location_id, visit_date, queue_no)
+VALUES
+  ((SELECT id FROM patients WHERE phone_number='+85510100007'), (SELECT id FROM locations WHERE name='Sisophon'), '2025-08-12', '5A'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100008'), (SELECT id FROM locations WHERE name='Sisophon'), '2025-08-12', '6');
+
+-- Ensure patient.queue_no mirrors the most recent visit (simple sync for seeded rows)
+UPDATE patients p
+SET queue_no = v.queue_no
+FROM visits v
+WHERE v.patient_id = p.id
+  AND v.visit_date = '2025-08-12';
+
+-- ─────────────────────────────
+-- Vitals (some patients get 2 records to simulate follow-ups)
+-- ─────────────────────────────
+INSERT INTO vitals (patient_id, height_cm, weight_kg, bmi, blood_pressure, temperature_c, vitals_notes) VALUES
+  ((SELECT id FROM patients WHERE phone_number='+85510100001'), 158, 54, 21.6, '112/70', 36.6, 'Initial screening'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100001'), 158, 55, 22.0, '118/72', 36.7, 'Follow-up weight'),
+
+  ((SELECT id FROM patients WHERE phone_number='+85510100004'), 170, 68, 23.5, '120/80', 36.8, 'Healthy baseline'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100004'), 170, 69, 23.9, '122/82', 36.7, 'Slight weight gain'),
+
+  ((SELECT id FROM patients WHERE phone_number='+85510100007'), 165, 62, 22.8, '118/76', 36.6, 'No complaints');
+
+-- ─────────────────────────────
+-- HEF (health equity fund awareness/possession)
+-- ─────────────────────────────
+INSERT INTO hef (patient_id, know_hef, have_hef, hef_notes) VALUES
+  ((SELECT id FROM patients WHERE phone_number='+85510100001'), TRUE,  FALSE, 'Aware but not enrolled'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100005'), TRUE,  TRUE,  'Has valid HEF card'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100007'), FALSE, FALSE, 'Not aware of HEF');
+
+-- ─────────────────────────────
+-- Visual Acuity
+-- ─────────────────────────────
+INSERT INTO visual_acuity (patient_id, left_pin, left_no_pin, right_pin, right_no_pin, visual_notes) VALUES
+  ((SELECT id FROM patients WHERE phone_number='+85510100001'), '6/12', '6/18', '6/9',  '6/12', 'Mild myopia suspected'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100005'), '6/6',  '6/9',  '6/6',  '6/9',  'Near-normal'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100007'), '6/18', '6/24', '6/12', '6/18', 'Blurred distance vision');
+
+-- ─────────────────────────────
+-- Presenting Complaint
+-- ─────────────────────────────
+INSERT INTO presenting_complaint (patient_id, history, red_flags, systems_review, drug_allergies) VALUES
+  ((SELECT id FROM patients WHERE phone_number='+85510100001'), 'Headaches, worse in sun', 'None', 'No chest pain/SOB', 'NKDA'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100005'), 'Eye strain after reading', 'None', 'No neuro deficits', 'NKDA');
+
+-- ─────────────────────────────
+-- History
+-- ─────────────────────────────
+INSERT INTO history (patient_id, past, drug_and_treatment, family, social, systems_review) VALUES
+  ((SELECT id FROM patients WHERE phone_number='+85510100001'), 'No chronic illnesses', 'Occasional paracetamol', 'Mother HTN', 'Farmer, non-smoker', 'Unremarkable'),
+  ((SELECT id FROM patients WHERE phone_number='+85510100004'), 'Childhood asthma (resolved)', 'Salbutamol prn (past)', 'Father DM2', 'Teacher, rare alcohol', 'No GI/GU issues');
+
+-- ─────────────────────────────
+-- Consultations
+-- ─────────────────────────────
+INSERT INTO consultation (patient_id, doctor_id, consultation_notes, prescription) VALUES
+  (
+    (SELECT id FROM patients WHERE phone_number='+85510100001'),
+    (SELECT id FROM users WHERE username='alice'),
+    'Probable tension headache; hydration and rest advised',
+    'Paracetamol 500mg q6h prn x3 days'
+  ),
+  (
+    (SELECT id FROM patients WHERE phone_number='+85510100005'),
+    (SELECT id FROM users WHERE username='charlie'),
+    'Eye strain; recommend refraction and ergonomic advice',
+    'Artificial tears prn'
+  );
+
+-- ─────────────────────────────
+-- Referrals (must use one of the allowed referral_type values)
+-- Allowed: 'MongKol Borey Hospital','Optometrist','Dentist','Poipet Referral Hospital','Bong Bondol','SEVA','WSAudiology'
+-- ─────────────────────────────
+INSERT INTO referral (patient_id, doctor_id, consultation_id, referral_date, referral_symptom, referral_symptom_duration, referral_reason, referral_type)
+VALUES
+  (
+    (SELECT id FROM patients WHERE phone_number='+85510100005'),
+    (SELECT id FROM users WHERE username='charlie'),
+    (SELECT id FROM consultation WHERE patient_id=(SELECT id FROM patients WHERE phone_number='+85510100005') ORDER BY id DESC LIMIT 1),
+    '2025-08-12',
+    'Eye strain',
+    '2 months',
+    'Formal refraction and visual aids',
+    'Optometrist'
+  );
+
+-- ─────────────────────────────
+-- Physiotherapy
+-- ─────────────────────────────
+INSERT INTO physiotherapy (patient_id, doctor_id, pain_areas_description) VALUES
+  (
+    (SELECT id FROM patients WHERE phone_number='+85510100004'),
+    (SELECT id FROM users WHERE username='davy'),
+    'Lower back ache after farm work'
+  );
+
+COMMIT;
+
+-- Quick sanity checks (optional):
+-- SELECT id,name FROM locations ORDER BY id;
+-- SELECT id,username FROM users ORDER BY id;
+-- SELECT id,english_name,location_id,queue_no FROM patients ORDER BY id;
+-- SELECT * FROM visits ORDER BY created_at DESC;

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -1,0 +1,21 @@
+// tests/users.test.js
+
+const request = require('supertest');
+const app = require('../server');
+
+describe('Public Users API', () => {
+  test('POST /api/users creates username-only user without token', async () => {
+    const uname = 'testuser_' + Math.random().toString(36).slice(2,8);
+    const res = await request(app)
+      .post('/api/users')
+      .send({ username: uname });
+    expect(res.status).toBe(201);
+    expect(res.body.user.username).toBe(uname);
+  });
+
+  test('GET /api/users lists users (public)', async () => {
+    const res = await request(app).get('/api/users');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+});


### PR DESCRIPTION
Updates:
- Removes the authentication token needed. Allows front end to just create new user with just a username.
- Adds a separate locations table. When frontend calls the api, it should return the list of locations that the health screenings are being done in, instead of the addresses of the current patients. 
- Adds an additional "location" field under the patient table, not dependent on the address.
- Adds one combined api call for adding, updating, deleting a patient's info based on patient info, vitals, hef and queue number. Also, allows for adding, updating, deleting each of these components individually.
- Stores the queue number in the patient table.
- Adds backend test cases.